### PR TITLE
Fix ${} to $() as per IRC conversation.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -94,7 +94,7 @@ Minimal example:
     stats_endpoint = tcp://127.0.0.1:5557
 
     [watcher:web]
-    cmd = chaussette --fd ${socket:web} --backend meinheld server.app
+    cmd = chaussette --fd $(circus.sockets.web) --backend meinheld server.app
     use_sockets = True
     numprocesses = 5
 


### PR DESCRIPTION
I was trying to use Chaussette with Circus and this was incorrect in the docs. I told Tarek I'd submit a pull request. :)
