### PR TITLE
Add backend for Gevent-based ws4py.

### DIFF
--- a/chaussette/backend/__init__.py
+++ b/chaussette/backend/__init__.py
@@ -18,6 +18,12 @@ except ImportError:
     pass
 
 try:
+    from chaussette.backend import _geventws4py
+    _backends['geventws4py'] = _geventws4py.Server
+except ImportError:
+    pass
+
+try:
     from chaussette.backend import _meinheld
     _backends['meinheld'] = _meinheld.Server
 except ImportError:

--- a/chaussette/backend/_geventws4py.py
+++ b/chaussette/backend/_geventws4py.py
@@ -1,0 +1,14 @@
+import socket
+from ws4py.server.geventserver import UpgradableWSGIHandler
+from chaussette.backend._gevent import Server as GeventServer
+
+
+class CustomWSGIHandler(UpgradableWSGIHandler):
+    def __init__(self, sock, address, server, rfile=None):
+        if server.socket_type == socket.AF_UNIX:
+            address = ['0.0.0.0']
+        UpgradableWSGIHandler.__init__(self, sock, address, server, rfile)
+
+
+class Server(GeventServer):
+    handler_class = CustomWSGIHandler

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -124,6 +124,8 @@ but it also provides more efficient back ends:
 - **eventlet** -- based on Eventlet's wsgi server
 - **geventwebsocket** -- Gevent's **pywsgi** server coupled with
   **geventwebsocket** handler.
+- **geventws4py** -- Gevent's **pywsgi** server coupled with
+  **ws4py** handler.
 
 
 You can select your backend by using the **--backend** option and providing
@@ -137,6 +139,7 @@ are installed:
 - **waitress** : `pip install waitress`
 - **eventlet** : `pip install eventlet`
 - **geventwebsocket**: `pip install gevent-websocket`
+- **geventws4py**: `pip install ws4py`
 
 
 If you want to add your favorite WSGI Server as a backend to Chaussette,


### PR DESCRIPTION
ws4py: https://github.com/Lawouach/WebSocket-for-Python

This Gevent-based WebSocket backend allows to negotiate WebSocket upgrade inside a WSGI application. The existing gevent-websocket backend always upgrade to WebSocket _before_ calling a WSGI application.
