### PR TITLE
Avoid crash when using waitress due to new socket_type and address_family options

### DIFF
--- a/chaussette/backend/_waitress.py
+++ b/chaussette/backend/_waitress.py
@@ -6,17 +6,23 @@ class Server(WSGIServer):
     address_family = socket.AF_INET
     socket_type = socket.SOCK_STREAM
 
-    def __init__(self, listener, application=None, backlog=2048):
+    def __init__(self, listener, application=None, backlog=2048, 
+                 socket_type=socket.SOCK_STREAM,
+                 address_family=socket.AF_INET):
         host, port = listener
         if host.startswith('fd://'):
             self._fd = int(host.split('://')[1])
         else:
             self._fd = None
 
+        self._chaussette_family_and_type = address_family, socket_type
         super(Server, self).__init__(application, backlog=backlog, host=host,
                                      port=port)
 
     def create_socket(self, family, type):
+        #Ignore parameters passed by waitress to use chaussette options
+        family, type = self._chaussette_family_and_type
+
         self.family_and_type = family, type
         if self._fd is None:
             sock = socket.socket(family, type)


### PR DESCRIPTION
When running with waitress as a backend chaussette currently crashes due to the new socket_type and address_family options which were not added to the waitress backend.

The patch avoids the crash and stores the options to use them inside the create_socket call to override the family and type passed by waitress itself.
