### PR TITLE
 Paste configured logging.

### DIFF
--- a/chaussette/_paste.py
+++ b/chaussette/_paste.py
@@ -1,3 +1,5 @@
+import configparser
+import logging.config
 import os.path
 try:
     from paste.deploy import loadapp
@@ -6,4 +8,9 @@ except ImportError:
 
 
 def paste_app(path):
-    return loadapp('config:%s' % os.path.abspath(path))
+    abspath = os.path.abspath(path)
+    try:
+        logging.config.fileConfig(abspath)
+    except configparser.NoSectionError:
+        pass
+    return loadapp('config:%s' % abspath)


### PR DESCRIPTION
If a _Python Paste_ configuration contains logging configuration use it to configure the logging module.
