### PR TITLE
Fix small typo in serve_paste.

### DIFF
--- a/chaussette/server.py
+++ b/chaussette/server.py
@@ -57,7 +57,7 @@ _NO_UNIX = ('waitress', 'fastgevent', 'eventlet')
 
 
 def serve_paste(app, global_conf, **kw):
-    port = int(kw.get(kw['port'], 8080))
+    port = int(kw.get('port', 8080))
     host = kw.get('host', '127.0.0.1')
     backlog = int(kw.get('backlog', 2048))
     backend = kw.get('backend', 'wsgiref')


### PR DESCRIPTION
Typo prevents ports other than 8080 from being used properly. Thanks.
