### PR TITLE
Pass default log in gevent backends, making use of default WSGIServer HTTP requests logging

### DIFF
--- a/chaussette/backend/_fastgevent.py
+++ b/chaussette/backend/_fastgevent.py
@@ -21,6 +21,5 @@ class Server(WSGIServer):
                                     self.socket_type, backlog=backlog)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.server_address = self.socket.getsockname()
-        log = None
         super(Server, self).__init__(self.socket, application, None, spawn,
                                      log, handler_class, environ, **ssl_args)

--- a/chaussette/backend/_gevent.py
+++ b/chaussette/backend/_gevent.py
@@ -30,6 +30,5 @@ class Server(WSGIServer):
                                     self.socket_type, backlog=backlog)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.server_address = self.socket.getsockname()
-        log = None
         super(Server, self).__init__(self.socket, application, None, spawn,
                                      log, handler_class, environ, **ssl_args)

--- a/chaussette/backend/_geventwebsocket.py
+++ b/chaussette/backend/_geventwebsocket.py
@@ -24,6 +24,5 @@ class Server(WSGIServer):
                                     self.socket_type, backlog=backlog)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.server_address = self.socket.getsockname()
-        log = None
         super(Server, self).__init__(self.socket, application, None, spawn,
                                      log, handler_class, environ, **ssl_args)


### PR DESCRIPTION
Passing log='default' to gevent WSGIServer will log HTTP requests, which is quite useful
e.g:
0.0.0.0 - - [2013-11-19 12:08:00] "GET / HTTP/1.1" 200 128 0.000725
