### PR TITLE
Specify universal wheels to be built

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1


### PR DESCRIPTION
This means that [wheels](https://pypi.python.org/pypi/wheel/) when built will be universal, aka able to be installed on python 2 or 3. 

Make sure your package will be a [green one](http://pythonwheels.com/)! ^_^
