### PR TITLE
Adding --graceful_timeout argument

### DIFF
--- a/chaussette/backend/_fastgevent.py
+++ b/chaussette/backend/_fastgevent.py
@@ -3,6 +3,8 @@ from gevent import monkey
 import socket
 from gevent.wsgi import WSGIServer
 
+import signal
+from gevent import signal as gevent_signal
 from chaussette.util import create_socket
 
 
@@ -14,7 +16,8 @@ class Server(WSGIServer):
     def __init__(self, listener, application=None, backlog=None,
                  spawn='default', log='default', handler_class=None,
                  environ=None, socket_type=socket.SOCK_STREAM,
-                 address_family=socket.AF_INET, **ssl_args):
+                 address_family=socket.AF_INET, graceful_timeout=None,
+                 **ssl_args):
         monkey.noisy = False
         monkey.patch_all()
         host, port = listener
@@ -22,5 +25,10 @@ class Server(WSGIServer):
                                     self.socket_type, backlog=backlog)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.server_address = self.socket.getsockname()
+
+        if graceful_timeout is not None:
+            self.stop_timeout = graceful_timeout
+            gevent_signal(signal.SIGTERM, self.stop)
+
         super(Server, self).__init__(self.socket, application, None, spawn,
                                      log, handler_class, environ, **ssl_args)

--- a/chaussette/backend/_gevent.py
+++ b/chaussette/backend/_gevent.py
@@ -3,6 +3,8 @@ from gevent import monkey
 import socket
 from gevent.pywsgi import WSGIServer, WSGIHandler
 from chaussette.util import create_socket
+import signal
+from gevent import signal as gevent_signal
 
 
 class CustomWSGIHandler(WSGIHandler):
@@ -20,8 +22,8 @@ class Server(WSGIServer):
 
     def __init__(self, listener, application=None, backlog=None,
                  spawn='default', log='default', handler_class=None,
-                 environ=None, socket_type=None,
-                 address_family=None, **ssl_args):
+                 environ=None, socket_type=None, address_family=None,
+                 graceful_timeout=None, **ssl_args):
         monkey.noisy = False
         monkey.patch_all()
         if address_family:
@@ -36,6 +38,11 @@ class Server(WSGIServer):
                                     self.socket_type, backlog=backlog)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.server_address = self.socket.getsockname()
+
+        if graceful_timeout is not None:
+            self.stop_timeout = graceful_timeout
+            gevent_signal(signal.SIGTERM, self.stop)
+
         super(Server, self).__init__(self.socket, application, None, spawn,
                                      log, self.handler_class, environ,
                                      **ssl_args)

--- a/chaussette/backend/_geventwebsocket.py
+++ b/chaussette/backend/_geventwebsocket.py
@@ -4,6 +4,8 @@ import socket
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
 from chaussette.util import create_socket
+import signal
+from gevent import signal as gevent_signal
 
 
 class Server(WSGIServer):
@@ -14,7 +16,8 @@ class Server(WSGIServer):
     def __init__(self, listener, application=None, backlog=None,
                  spawn='default', log='default', handler_class=None,
                  environ=None, socket_type=socket.SOCK_STREAM,
-                 address_family=socket.AF_INET, **ssl_args):
+                 address_family=socket.AF_INET, graceful_timeout=None,
+                 **ssl_args):
         monkey.noisy = False
         monkey.patch_all()
         self.address_family = address_family
@@ -26,5 +29,10 @@ class Server(WSGIServer):
                                     self.socket_type, backlog=backlog)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.server_address = self.socket.getsockname()
+
+        if graceful_timeout is not None:
+            self.stop_timeout = graceful_timeout
+            gevent_signal(signal.SIGTERM, self.stop)
+
         super(Server, self).__init__(self.socket, application, None, spawn,
                                      log, handler_class, environ, **ssl_args)

--- a/chaussette/server.py
+++ b/chaussette/server.py
@@ -11,7 +11,8 @@ from chaussette.backend import get, backends
 
 def make_server(app, host=None, port=None, backend='wsgiref', backlog=2048,
                 spawn=None, logger=None, address_family=socket.AF_INET,
-                socket_type=socket.SOCK_STREAM):
+                socket_type=socket.SOCK_STREAM, graceful_timeout=None):
+
     logger = logger or chaussette_logger
     logger.info('Application is %r' % app)
     if host.startswith('fd://') or host.startswith('unix:'):
@@ -30,6 +31,8 @@ def make_server(app, host=None, port=None, backend='wsgiref', backlog=2048,
     }
     if spawn is not None:
         server_class_kwargs['spawn'] = spawn
+    if graceful_timeout is not None:
+        server_class_kwargs['graceful_timeout'] = graceful_timeout
 
     try:
         server = server_class((host, port), app, **server_class_kwargs)
@@ -56,6 +59,8 @@ _SOCKET_TYPE = {
 }
 
 _NO_UNIX = ('waitress', 'fastgevent', 'eventlet')
+
+_SUPPORTS_GRACEFUL_TIMEOUT = ('gevent', 'fastgevent', 'geventwebsocket')
 
 
 def serve_paste(app, global_conf, **kw):
@@ -124,6 +129,10 @@ def main():
     parser.add_argument('--spawn', type=int, default=None,
                         help="Spawn type, only makes sense if the backend "
                              "supports it (gevent)")
+    parser.add_argument('--graceful-timeout', type=int, default=None,
+                        help="Graceful shutdown timeout for existing requests "
+                             "to complete, only for backends that support it "
+                             "(%s)" % ', '.join(_SUPPORTS_GRACEFUL_TIMEOUT))
     parser.add_argument('application', default='chaussette.util.hello_app',
                         nargs='?')
     parser.add_argument('arguments', default=[], nargs='*',
@@ -145,6 +154,12 @@ def main():
 
     logger = chaussette_logger
     configure_logger(logger, args.loglevel, args.logoutput)
+
+    if args.graceful_timeout is not None and \
+            args.backend not in _SUPPORTS_GRACEFUL_TIMEOUT:
+        logger.info('Sorry %r does not support --graceful_timeout' %
+                    args.backend)
+        sys.exit(0)
 
     if application.startswith('paste:'):
         from chaussette._paste import paste_app
@@ -179,6 +194,7 @@ def main():
             httpd = make_server(app, host=host, port=args.port,
                                 backend=args.backend, backlog=args.backlog,
                                 spawn=args.spawn,
+                                graceful_timeout=args.graceful_timeout,
                                 logger=logger,
                                 address_family=address_family,
                                 socket_type=_SOCKET_TYPE[args.socket_type])


### PR DESCRIPTION
I recently created an issue for adding "graceful shutdown" options to chaussette - so that when shutting down a backend will stop receiving new connections immediately, but wait some period for existing connections to complete.
https://github.com/mozilla-services/chaussette/issues/50

This pull request implements this feature for the gevent and geventwebsockets backends.  I'm not familiar with the other backends, so I've left them out for now.

Please note the change to moving the gevent monkey patching to immediately after the import.  Without this I was getting a "Exception KeyError in module threading" on shutdown, indicating that the system threading module was used before gevent could patch it.