### PR TITLE
Allowing additional commandline arguments which are ignored by chaussette

### DIFF
--- a/chaussette/server.py
+++ b/chaussette/server.py
@@ -126,6 +126,8 @@ def main():
                              "supports it (gevent)")
     parser.add_argument('application', default='chaussette.util.hello_app',
                         nargs='?')
+    parser.add_argument('arguments', default=[], nargs='*',
+                        help="Optional arguments you may need for your app")
     parser.add_argument('--pre-hook', type=str, default=None)
     parser.add_argument('--post-hook', type=str, default=None)
     parser.add_argument('--python-path', type=str, default=None)


### PR DESCRIPTION
Useful for eg. to pass arguments like the circus variable $(circus.wid) to the application.
