### PR TITLE
Gevent monkey patching must happen early to avoid "Exception KeyError in module threading" errors on shutdown

### DIFF
--- a/chaussette/backend/__init__.py
+++ b/chaussette/backend/__init__.py
@@ -76,3 +76,8 @@ def get(name):
 
 def backends():
     return sorted(_backends.keys())
+
+
+def is_gevent_backend(backend):
+    return backend in ('gevent', 'fastgevent', 'geventwebsocket',
+                       'geventws4py')

--- a/chaussette/backend/_fastgevent.py
+++ b/chaussette/backend/_fastgevent.py
@@ -1,5 +1,3 @@
-from gevent import monkey
-
 import socket
 from gevent.wsgi import WSGIServer
 
@@ -15,8 +13,6 @@ class Server(WSGIServer):
                  spawn='default', log='default', handler_class=None,
                  environ=None, socket_type=socket.SOCK_STREAM,
                  address_family=socket.AF_INET, **ssl_args):
-        monkey.noisy = False
-        monkey.patch_all()
         host, port = listener
         self.socket = create_socket(host, port, self.address_family,
                                     self.socket_type, backlog=backlog)

--- a/chaussette/backend/_gevent.py
+++ b/chaussette/backend/_gevent.py
@@ -1,5 +1,3 @@
-from gevent import monkey
-
 import socket
 from gevent.pywsgi import WSGIServer, WSGIHandler
 from chaussette.util import create_socket
@@ -22,8 +20,6 @@ class Server(WSGIServer):
                  spawn='default', log='default', handler_class=None,
                  environ=None, socket_type=None,
                  address_family=None, **ssl_args):
-        monkey.noisy = False
-        monkey.patch_all()
         if address_family:
             self.address_family = address_family
         if socket_type:

--- a/chaussette/backend/_geventwebsocket.py
+++ b/chaussette/backend/_geventwebsocket.py
@@ -1,5 +1,3 @@
-from gevent import monkey
-
 import socket
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
@@ -15,8 +13,6 @@ class Server(WSGIServer):
                  spawn='default', log='default', handler_class=None,
                  environ=None, socket_type=socket.SOCK_STREAM,
                  address_family=socket.AF_INET, **ssl_args):
-        monkey.noisy = False
-        monkey.patch_all()
         self.address_family = address_family
         self.socket_type = socket_type
 

--- a/chaussette/server.py
+++ b/chaussette/server.py
@@ -6,7 +6,7 @@ import socket
 
 from chaussette import logger as chaussette_logger
 from chaussette.util import import_string, configure_logger, LOG_LEVELS
-from chaussette.backend import get, backends
+from chaussette.backend import get, backends, is_gevent_backend
 
 
 def make_server(app, host=None, port=None, backend='wsgiref', backlog=2048,
@@ -140,6 +140,11 @@ def main():
     parser.add_argument('--log-output', dest='logoutput', default='-',
                         help="log output")
     args = parser.parse_args()
+
+    if is_gevent_backend(args.backend):
+        from gevent import monkey
+        monkey.noisy = False
+        monkey.patch_all()
 
     application = args.application
 


### PR DESCRIPTION
The current monkey patching only when the Server is instantiated means that gevent based servers will log errors like:
`Exception KeyError: KeyError(15566960,) in <module 'threading' from '/usr/lib64/python2.7/threading.pyc'> ignored`
when the server shuts down.

Previous attempted fixes (ie https://github.com/circus-tent/chaussette/pull/62) would cause gevent monkey patching to be run even when these were not the chosen backends.

This commit moves the gevent monkey patching to the main() function, after a check to see if the chosen backend is gevent based.
