### PR TITLE
[eventlet] Enable for Python 3

### DIFF
--- a/chaussette/backend/__init__.py
+++ b/chaussette/backend/__init__.py
@@ -30,6 +30,11 @@ try:
 except ImportError:
     pass
 
+try:
+    from chaussette.backend import _eventlet
+    _backends['eventlet'] = _eventlet.Server
+except ImportError:
+    pass
 
 PY3 = sys.version_info[0] == 3
 
@@ -52,12 +57,6 @@ if not PY3:
     try:
         from chaussette.backend import _geventws4py
         _backends['geventws4py'] = _geventws4py.Server
-    except ImportError:
-        pass
-
-    try:
-        from chaussette.backend import _eventlet
-        _backends['eventlet'] = _eventlet.Server
     except ImportError:
         pass
 

--- a/chaussette/tests/test_backend.py
+++ b/chaussette/tests/test_backend.py
@@ -13,7 +13,7 @@ PY2 = ['bjoern', 'eventlet', 'fastgevent', 'gevent',
        'socketio', 'tornado', 'waitress',
        'wsgiref']
 PYPY = ['tornado', 'waitress', 'wsgiref']
-PY3 = ['meinheld', 'tornado', 'waitress', 'wsgiref']
+PY3 = ['eventlet', 'meinheld', 'tornado', 'waitress', 'wsgiref']
 
 
 class TestBackend(unittest.TestCase):


### PR DESCRIPTION
As of eventlet v0.17, Python 3 support has been available. The API hasn't changed, so all that was necessary to enable it for chaussette was to move the import block.