### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,17 +69,17 @@ backends:
 
 In these examples, we start a standalone WSGI server, but the spirit of
 chaussette is to be managed by Circus_, as described
-http://chaussette.readthedocs.org/en/latest/#using-chaussette-in-circus
+https://chaussette.readthedocs.io/en/latest/#using-chaussette-in-circus
 
    
 Links
 -----
 
-- The full documentation is located at: http://chaussette.readthedocs.org
+- The full documentation is located at: https://chaussette.readthedocs.io
 - You can reach us for any feedback, bug report, or to contribute, at
   https://github.com/circus-tent/chaussette
 
-.. _Circus: http://circus.readthedocs.org
+.. _Circus: https://circus.readthedocs.io
 .. _Django: https://docs.djangoproject.com
 .. _flask: http://flask.pocoo.org/
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,7 +100,7 @@ Using Chaussette in Circus
 
 The typical use case is to run Chaussette processes under a process
 and socket manager.  Chaussette was developed to run under `Circus
-<http://circus.readthedocs.org>`_, which takes care of binding the
+<https://circus.readthedocs.io>`_, which takes care of binding the
 socket and spawning Chaussette processes.
 
 To run your WSGI application using Circus, define a *socket* section in your
@@ -247,13 +247,13 @@ Chaussette child processes that accept connections on that socket.
 For more information about this design, read :
 
 - http://blog.ziade.org/2012/06/12/shared-sockets-in-circus.
-- http://circus.readthedocs.org/en/latest/for-ops/sockets/
+- https://circus.readthedocs.io/en/latest/for-ops/sockets/
 
 
 Useful links
 ============
 
 - Repository : https://github.com/circus-tent/chaussette
-- Documentation : https://chaussette.readthedocs.org
+- Documentation : https://chaussette.readthedocs.io
 - Continuous Integration: https://travis-ci.org/circus-tent/chaussette
     

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if sys.version_info[0] == 2:
 
 setup(name='chaussette',
       version=__version__,
-      url='http://chaussette.readthedocs.org',
+      url='https://chaussette.readthedocs.io',
       packages=find_packages(exclude=['examples', 'examples.simple_chat']),
       description=("A WSGI Server for Circus"),
       long_description=README,


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.