### PR TITLE
Fix Invalid host/port with waitress 1.x

### DIFF
--- a/chaussette/__init__.py
+++ b/chaussette/__init__.py
@@ -2,4 +2,4 @@ import logging
 
 logger = logging.getLogger('chaussette')
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/chaussette/backend/_waitress.py
+++ b/chaussette/backend/_waitress.py
@@ -13,6 +13,7 @@ class Server(WSGIServer):
         host, port = listener
         if host.startswith('fd://'):
             self._fd = int(host.split('://')[1])
+            host = '0.0.0.0'
         else:
             self._fd = None
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,6 +4,12 @@ Chaussette WSGI Server
 .. image:: images/chaussette.png
    :align: right
 
+**Chaussette-backport** is a fork of chaussette as chaussette is not working
+properly with current waitress & more. See `https://github.com/circus-tent/chaussette/pull/89`
+
+**Chaussette is a hard work, the idea of backporting the project is juste to be able to install
+fixed version of the application. Feel free to contact us if you think we should remove this backport
+from Pypi.
 
 **Chaussette** is a WSGI server you can use to run your Python WSGI
 applications.
@@ -256,4 +262,4 @@ Useful links
 - Repository : https://github.com/circus-tent/chaussette
 - Documentation : https://chaussette.readthedocs.io
 - Continuous Integration: https://travis-ci.org/circus-tent/chaussette
-    
+

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if sys.version_info[0] == 2:
         tests_require += ['gevent', 'gevent-websocket', 'eventlet',
                           'gevent-socketio', 'bjoern']
 
-setup(name='chaussette',
+setup(name='chaussette-backport',
       version=__version__,
       url='https://chaussette.readthedocs.io',
       packages=find_packages(exclude=['examples', 'examples.simple_chat']),


### PR DESCRIPTION
Not very elegant sorry but I need to use waitress 1.4 due to security advisory (ref: https://github.com/Pylons/waitress/security/advisories/GHSA-m5ff-3wj3-8ph4) waitress don't like fd://xxx hosts